### PR TITLE
W6: Execute In File Dir for non-Windows machines

### DIFF
--- a/data/osa-6/1-tiedostojen-lukeminen.md
+++ b/data/osa-6/1-tiedostojen-lukeminen.md
@@ -106,7 +106,7 @@ Kirjoita funktio `suurin`, joka lukee tiedoston ja palauttaa suurimman tiedostos
 
 Huomaa, että tiedoston nimi on aina `luvut.txt` eikä funktiolle anneta parametria.
 
-Huom! Jos käytät Windowsia eikä testi löydä VS Codessa tiedostoa, voit kokeilla seuraavaa:
+Huom! Jos VS Code ei löydä tiedostoa vaikka olet tarkastanut tiedoston nimen kirjoitusasun, voit kokeilla seuraavaa:
 
 * Mene asetuksiin valikosta _File_ -> _Preferences_ -> _Settings_
 * Etsi muutettava kohta hakusanalla "executeinfile"


### PR DESCRIPTION
I had to run the  `Execute In File Dir` trick Cubbli Linux as well to get things working. This PR simply modifies the language in W6E1 s.t. the trick is no longer described as Windows specific.

Curiously, I had no issue with W6E1 itself, but the problem only manifested for later exercises. I'm not sure what the difference could have been.