### PR TITLE
4-6 korjaus tehtävänantoon

### DIFF
--- a/data/osa-4/6-lisaa-rakenteista.md
+++ b/data/osa-4/6-lisaa-rakenteista.md
@@ -279,7 +279,7 @@ False
 
 </sample-output>
 
-Kirjoita metodia hyödyntäen funktio `poista_isot`, joka saa parametrikseen listan merkkijonoja. Funktio palauttaa uuden listan, jolla on sen paramentrina olevasta listasta ne merkkijonot, jotka koostuvat kokonaan isoista kirjaimista.
+Kirjoita metodia hyödyntäen funktio `poista_isot`, joka saa parametrikseen listan merkkijonoja. Funktio palauttaa uuden listan, jolla on sen parametrina olevasta listasta ne merkkijonot, jotka koostuvat kokonaan pienistä kirjaimista.
 
 
 Esimerkki funktion käytöstä:


### PR DESCRIPTION
> Kirjoita metodia hyödyntäen funktio poista_isot, joka saa parametrikseen listan merkkijonoja. Funktio palauttaa uuden listan, jolla on sen paramentrina olevasta listasta ne merkkijonot, jotka koostuvat kokonaan isoista kirjaimista.

Toisessa virkkeessä on typo sekä ajatusvirhe. Funktion on tarkoitus palauttaa pienistä kirjaimista koostuvat merkkijonot.