### PR TITLE
poista isot -tehtävän väärä tehtävänanto korjattu

### DIFF
--- a/data/osa-4/6-lisaa-rakenteista.md
+++ b/data/osa-4/6-lisaa-rakenteista.md
@@ -279,7 +279,7 @@ False
 
 </sample-output>
 
-Kirjoita metodia hyödyntäen funktio `poista_isot`, joka saa parametrikseen listan merkkijonoja. Funktio palauttaa uuden listan, jolla on sen parametrina olevasta listasta ne merkkijonot, jotka koostuvat kokonaan pienistä kirjaimista.
+Kirjoita metodia hyödyntäen funktio `poista_isot`, joka saa parametrikseen listan merkkijonoja. Funktio palauttaa uuden listan, jolla on sen parametrina olevasta listasta ne merkkijonot, jotka eivät koostu kokonaan isoista kirjaimista.
 
 
 Esimerkki funktion käytöstä:


### PR DESCRIPTION
Testit toimivat väärin / tehtävänanto on väärä. Aivan saatanan jurppivaa. Kyse ei ole siis siitä, että pitäisi saada karsittu lista, jolla on pelkästään täysin pienistä kirjaimista koostuvat stringit, vaan siitä, että pitää saada karsittu lista, josta on poistettu pelkästään isoista kirjaimista koostuvat stringit. Valot päälle nyt ja tarkkuutta jatkossa.