### PR TITLE
rivin lopun ;-merkin poisto csv:n automaattigeneroinnissa

### DIFF
--- a/data/osa-6/2-tiedostojen-kirjoittaminen.md
+++ b/data/osa-6/2-tiedostojen-kirjoittaminen.md
@@ -239,6 +239,7 @@ with open("koodarit.csv", "w") as tiedosto:
         rivi = ""
         for arvo in koodari:
             rivi += f"{arvo};"
+        rivi = rivi[:-1]
         tiedosto.write(rivi+"\n")
 ```
 


### PR DESCRIPTION
Esimerkissä siitä, miten listasta saa tehtyä .csv:n, rivien loppuun jää turha ja potentiaalisesti asioita sotkeva puolipiste. Lisätty esimerkkiin koodirivi, joka poistaa sen.