### PR TITLE
4.2: funktion paluuarvon tyyppivihjeen esittely

### DIFF
--- a/data/osa-4/2-lisaa-funktioista.md
+++ b/data/osa-4/2-lisaa-funktioista.md
@@ -597,6 +597,16 @@ def tulosta_monesti(viesti : str, kerrat : int):
 
 Tämä kertoo funktion käyttäjälle, että parametrin `viesti` on tarkoitus olla merkkijono, kun taas parametrin `kerrat` on tarkoitus olla kokonaisluku.
 
-Huomaa kuitenkin, että tyyppivihje ainoastaan neuvoo, mikä tyypin tulisi olla, mutta ei valvo sitä. Jos funktiolle annetaan väärän tyyppinen parametri, funktio suoritetaan kuitenkin, mutta se toimii mahdollisesti väärin.
+Vastaavasti funktion paaluarvon tyypin voi vihjata funktion määrittelyssä:
+
+```python
+def kysy_nimi() -> str:
+    nimi = input("Mikä on nimesi? ")
+    return nimi
+ ```
+
+Tämä kertoo funktion käyttäjälle, että funktion on tarkoitus palauttaa merkkijono. 
+
+Huomaa kuitenkin, että tyyppivihje ainoastaan neuvoo, mikä tyypin tulisi olla, mutta ei valvo sitä. Jos funktiolle annetaan väärän tyyppinen parametri tai se palauttaa väärän tyyppisen arvon, funktio suoritetaan kuitenkin, mutta se toimii mahdollisesti väärin.
 
 <quiz id="d752142a-9e54-5cdb-acb9-b19c9bf4673e"></quiz>


### PR DESCRIPTION
Paluuarvon tyyppivihje ilmestyy käyttöön ilman selitystä kappaleessa 5.2, sen esittely sopisi kappaleen 4.2 loppuun. 

Mahdollisesti jokin kuvaavampi esimerkki olisi paikallaan? Käytin kappaleessa aiemmin esiteltyä funktiota tuttuuden vuoksi

Tähän voisi myös lisätä maininnan, että on tarjolla työkaluja, jotka hoitavat tyyppitarkistuksen (ja paljon muuta). Joku näitä paremmin tunteva voisi ehkä jopa vinkata hyviä työkaluja, tai jos näistä puhutaan myöhemmin kurssilla, viitteen tulevaan?