### PR TITLE
6.2: ylimääräinen osuma muistavan sanakirjan haussa

### DIFF
--- a/data/osa-6/2-tiedostojen-kirjoittaminen.md
+++ b/data/osa-6/2-tiedostojen-kirjoittaminen.md
@@ -577,7 +577,6 @@ laukku - bag
 Valinta: **2**
 Anna sana: **car**
 auto - car
-roska - garbage
 1 - Lisää sana, 2 - Hae sanaa, 3 - Poistu
 Valinta: **2**
 Anna sana: **laukku**


### PR DESCRIPTION
Tehtävän osa06-16_muistava_sanakirja mallitulosteessa on ylimääräinen osuma sanojen haussa.

Hakusanalla "car" ei pitäisi tulla osumaa sanapariin "roska - garbage". Ainakaan tehtävänannossa ei ole tähän viittaavaa mainintaa, eivätkä paikalliset testit testaa tuleeko vastaavassa tilanteessa osuma (eli testeistä menee läpi koodi, jossa lähes-osumaa ei oteta huomioon).

Jos taas oli tarkoitus, että etsitään myös lähes matchaavia sanoja, tehtävänanto ja paikalliset testit pitäisi korjata vastaamaan tätä.