### PR TITLE
submitNB: typo ja isot kirjaimet kohdilleen

### DIFF
--- a/src/locales/common/fi.json
+++ b/src/locales/common/fi.json
@@ -26,7 +26,7 @@
     "moodleExercise": "Moodle tehtävä:",
     "sqlTrainerExercise": "SQL trainer tehtävä:",
     "points":"Pisteitä",
-    "submitNB":"Huom! Joissakin tehtävissä voit saada yksittäisen osan ratkaisusta osan tehtävän pisteistä lähettämällä ne palvelimelle valitsemalla 'submit solutiuon' testien suorituspainikkeen oikealla puolella olevan painikkeen avaamasta valikosta",
+    "submitNB":"Huom! Joissakin tehtävissä voit saada yksittäisen osan ratkaisusta osan tehtävän pisteistä lähettämällä ne palvelimelle valitsemalla 'Submit Solution' testien suorituspainikkeen oikealla puolella olevan painikkeen avaamasta valikosta",
     "installationGuideLink":"",
     "submitHowTo":"",
     "loginForExercise":"Kirjaudu sisään nähdäksesi tehtävänannon",


### PR DESCRIPTION
Monipisteisen tehtävän osapisteiden saamisen selityksessä on typo. Saman tien isot kirjaimet kohdilleen kuten ne tekstin kuvaamassa valikossa ovat.