### PR TITLE
_protected on konventio, ei kielen ominaisuus

### DIFF
--- a/data/osa-10/2-nakyvyysmaareet.md
+++ b/data/osa-10/2-nakyvyysmaareet.md
@@ -60,9 +60,9 @@ class MuistikirjaPro(Muistikirja):
 
 ## Suojatut piirteet
 
-Miten siis piilottaa piirteet asiakkailta mutta samaan aikaan avata ne mahdollisille aliluokille? Ratkaisuksi Pythonissa on määritelty _suojattu (eli protected)_  näkyvyys piirteille.
+Toisin kuin joistain muista ohjelmointikielistä, Pythonista ei suoraan löydy ominaisuutta joka piilottaa piirteet asiakkailta mutta samaan aikaan avata ne mahdollisille aliluokille. Ratkaisuksi Python-yhteisö onkin päätynyt _konventioon_ eli yleisesti ymmärrettyyn merkintätapaan _suojattuille (eli protected)_  piirteille.
 
-Piirre voidaan piilottaa kirjoittamalla sen tunnisteen (eli nimen) eteen kaksi alaviivaa:
+Koska piirre voidaan piilottaa kirjoittamalla sen tunnisteen (eli nimen) eteen kaksi alaviivaa
 
 ```python
 
@@ -71,7 +71,7 @@ def __init__(self):
 
 ```
 
-Mikäli alaviivoja on vain yksi, piirre on _suojattu_, eli se näkyy aliluokissa mutta ei asiakkaille:
+on yleisesti sovittu että yhdellä alaviivalla alkavat piirteet ovat tarkoitettu ainoastaan luokan ja sen aliluokkien käyttöön, eikä niitä tulisi käyttää suoraan sen ulkopuolelta.
 
 ```python
 
@@ -92,7 +92,7 @@ class Muistikirja:
         self._muistiinpanot = []
 
     def lisaa_muistiinpano(self, muistiinpano):
-        self.__muistiinpanot.append(muistiinpano)
+        self._muistiinpanot.append(muistiinpano)
 
     def palauta_muistiinpano(self, indeksi):
         return self._muistiinpanot[indeksi]


### PR DESCRIPTION
Alaviiva-alkuisten muuttujien status suojattuina on erittäin yleinen konventio, mutta ei varsinainen kielen ominaisuus. Tämän takia ilmaukset kuten "eli se näkyy aliluokissa mutta ei asiakkaille" on harhaanjohtavia.

Vaikka yksityisiinkin muuttujiin pääsee toki käsiksi ihan mistä vain scopesta, on tämä mielestäni merkityksellinen ero:
```python
>>> class C:
...   def __init__(self, public, protected, private):
...     self.public = public
...     self._protected = protected
...     self.__private = private
... 
>>> c = C(1,2,3)
>>> c.public
1
>>> c._protected
2
>>> c.__private
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'C' object has no attribute '__private'
>>> c._C__private  # private on vain uudelleennimetty muotoon "_<luokka>__<kentta>"
3
```