### PR TITLE
Uusi esimerkki

### DIFF
--- a/data/osa-10/3-olio-ohjelmoinnin-tekniikoita.md
+++ b/data/osa-10/3-olio-ohjelmoinnin-tekniikoita.md
@@ -220,7 +220,7 @@ Operaattori | Merkitys perinteisesti | Metodin nimi
 
 Lisää operaattoreita ja metodien nimien vastineita löydät helposti Googlella.
 
-Huomaa, että vain hyvin harvoin on tarvetta toteuttaa kaikkia operaatioita omassa luokassa - esimerkiksi jakaminen on loogisesti operaatio, jota on hankala perustella useimmille luokille (mitä tulee, kun jaetaan tiedosto kolmella saati toisella tiedostolla?) Tiettyjen operaattoreiden toteuttamisesta voi kuitenkin olla hyötyä, mikäli vastaavat operaatiot ovat loogisia luokalle.
+Huomaa, että vain hyvin harvoin on tarvetta toteuttaa kaikkia operaatioita omassa luokassa - esimerkiksi jakaminen on loogisesti operaatio, jota on hankala perustella useimmille luokille (mitä tulee, kun jaetaan opiskelija kolmella saati toisella opiskelijalla?) Tiettyjen operaattoreiden toteuttamisesta voi kuitenkin olla hyötyä, mikäli vastaavat operaatiot ovat loogisia luokalle.
 
 Tarkastellaan esimerkkinä luokkaa joka mallintaa yhtä muistiinpanoa. Kahden muistiinpanon yhdistäminen `+`-operaattorilla tuottaa uuden, yhdistetyn muistiinpanon, kun on toteutettu metodi `__add__`:
 


### PR DESCRIPTION
Esimerkki tiedoston jakamisesta toisella tiedostolla on sikäli hieman epäonninen, että standardikirjastoon kuuluva `Pathlib` juurikin käyttää hyväkseen jako-operaattorin ylikirjoittamista polkujen koostamiseen:

>[11.1.2.2. Operators](https://docs.python.org/3.6/library/pathlib.html#operators)
>
>The slash operator helps create child paths, similarly to os.path.join():
> ```
> >>> p = PurePath('/etc')
> >>> p
> PurePosixPath('/etc')
> >>> p / 'init.d' / 'apache2'
> PurePosixPath('/etc/init.d/apache2')
> >>> q = PurePath('bin')
> >>> '/usr' / q
> PurePosixPath('/usr/bin')
> ```
