### PR TITLE
Olion metodin koodiesimerkkiä muutettu vähemmän hämääväksi.

### DIFF
--- a/data/osa-8/1-oliot-ja-metodit.md
+++ b/data/osa-8/1-oliot-ja-metodit.md
@@ -93,8 +93,8 @@ kirja = {"nimi": "Vanhus ja Python", "kirjailija": "Ernest Pythonen", "vuosi": 1
 # Tulostetaan kaikki arvot
 # Metodikutsu values() kirjoitetaan muuttujan perään
 # pisteellä erotettuna
-for kirja in kirja.values():
-    print(kirja)
+for arvo in kirja.values():
+    print(arvo)
 ```
 
 <sample-output>


### PR DESCRIPTION
Se, että for-lauseessa iteraattorin nimen apumuuttujana käytetään itse muuttujan nimeä, voi häiritä monen oppimista. Muutettu iteroitavan muuttujan nimi toiseksi.