### PR TITLE
Hämäävä käyttämätön laskurimuuttuja poistettu

### DIFF
--- a/data/osa-11/2-lisaa-koosteesta.md
+++ b/data/osa-11/2-lisaa-koosteesta.md
@@ -260,8 +260,6 @@ class Kirja:
 class Kirjahylly:
     def __init__(self):
         self._kirjat = []
-        # laskuri iteraattoria varten
-        self.__laskuri = 0
 
     def lisaa_kirja(self, kirja: Kirja):
         self._kirjat.append(kirja)


### PR DESCRIPTION
Iteraattorin laskuri alustetaan esimerkissä __iter__-metodissa. Turha siellä mitään käyttämättä jääviä on pitää __init__issä hämäämässä.